### PR TITLE
Add license selection prompt to workspace template

### DIFF
--- a/workspace/.questions.json
+++ b/workspace/.questions.json
@@ -22,6 +22,17 @@
       "message": "Enter your github username",
       "defaultFrom": "npm.whoami",
       "required": true
+    },
+    {
+      "name": "____license____",
+      "message": "Choose a license",
+      "type": "list",
+      "options": [
+        "MIT",
+        "Apache-2.0",
+        "ISC"
+      ],
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
Add a license list question (MIT, Apache-2.0, ISC) to workspace/.questions.json, matching the module template.

Ensures ____license____ placeholders in workspace templates are populated with supported licenses instead of falling back to a generic prompt.