### PR TITLE
chore: update Postgres Docker image to constructiveio/postgres-plus:18

### DIFF
--- a/pgpm/workspace/.github/workflows/ci.yml
+++ b/pgpm/workspace/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     services:
       pg_db:
-        image: pyramation/postgres:17
+        image: constructiveio/postgres-plus:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password


### PR DESCRIPTION
## Summary
Updates the Postgres service container image in the `pgpm/workspace` CI workflow from `pyramation/postgres:17` to `constructiveio/postgres-plus:18`.

This was the only Postgres Docker image found across all workflows in this repo.

## Review & Testing Checklist for Human
- [ ] Verify `constructiveio/postgres-plus:18` image is accessible from GitHub Actions runners
- [ ] Run a test PR to confirm CI passes with the new image

### Notes
The `pnpm/workspace` CI workflow has no Docker service containers and was not changed.

Link to Devin session: https://app.devin.ai/sessions/1edd215ee7cc411db42b82dd68f944bb
Requested by: @pyramation