### PR TITLE
ci: fix pg_isready health check to use -U postgres

### DIFF
--- a/pgpm/workspace/.github/workflows/ci.yml
+++ b/pgpm/workspace/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Summary

Docker health checks run as `root` inside the container. `pg_isready` without `-U` defaults to the OS username (`root`), causing `FATAL: role "root" does not exist` every 10s in CI logs.

Fix: `pg_isready` → `pg_isready -U postgres` in the workspace CI template (`pgpm/workspace/.github/workflows/ci.yml`). This propagates to all new workspaces scaffolded from this boilerplate.

Link to Devin session: https://app.devin.ai/sessions/0d80c09a68154da68d1524f93741d21f
Requested by: @pyramation