### PR TITLE
feat: declare skills in workspace .boilerplate.json

### DIFF
--- a/pgpm/workspace/.boilerplate.json
+++ b/pgpm/workspace/.boilerplate.json
@@ -37,10 +37,6 @@
     {
       "source": "constructive-io/constructive",
       "skills": ["pgpm"]
-    },
-    {
-      "source": "constructive-io/constructive-skills",
-      "skills": ["constructive-data-modeling"]
     }
   ]
 }

--- a/pgpm/workspace/.boilerplate.json
+++ b/pgpm/workspace/.boilerplate.json
@@ -32,6 +32,16 @@
       "optionsFrom": "licenses",
       "required": true
     }
+  ],
+  "skills": [
+    {
+      "source": "constructive-io/constructive",
+      "skills": ["pgpm"]
+    },
+    {
+      "source": "constructive-io/constructive-skills",
+      "skills": ["constructive-data-modeling"]
+    }
   ]
 }
 


### PR DESCRIPTION
## Summary

Declares the `pgpm` skill in the workspace template's `.boilerplate.json`. After `pgpm init workspace` scaffolds the project, the pgpm CLI reads this config and runs `npx skills add` to install the skill automatically.

```json
"skills": [
  { "source": "constructive-io/constructive", "skills": ["pgpm"] }
]
```

Companion PRs:
- constructive-io/constructive#1271 (merged) — pgpm CLI `installSkills()` consumer
- constructive-io/dev-utils#87 — upstream `BoilerplateSkill` type in genomic

Link to Devin session: https://app.devin.ai/sessions/8a70e4bc95b947faa41db21e02ed818e
Requested by: @pyramation