### PR TITLE
ci: bump pgpm to 4.33.0 and tune Postgres durability in boilerplate CI

### DIFF
--- a/pgpm/workspace/.github/workflows/ci.yml
+++ b/pgpm/workspace/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       PGPORT: 5432
       PGUSER: postgres
       PGPASSWORD: password
-      PGPM_VERSION: 4.10.6
+      PGPM_VERSION: 4.33.0
 
     services:
       pg_db:
@@ -86,6 +86,11 @@ jobs:
 
       - name: Install pgpm CLI globally
         run: npm install -g pgpm@${{ env.PGPM_VERSION }}
+
+      # Durability is irrelevant for throwaway CI databases. Disabling fsync
+      # and synchronous commit avoids checkpoint I/O stalls on CI runners.
+      - name: Tune Postgres for CI (disable durability)
+        run: pgpm tune --yes
 
       - name: Build
         run: pnpm -r build


### PR DESCRIPTION
## Summary

The boilerplates ship a template CI workflow (`pgpm/workspace/.github/workflows/ci.yml`) to scaffolded projects, so new projects were being generated with pgpm 4.10.6 and no durability tuning. This bumps `PGPM_VERSION` 4.10.6 → 4.33.0 and adds a `pgpm tune --yes` step after pgpm install — same rollout as constructive-db#1926 / constructive#1337 / pgpm-modules#93 (disables fsync/synchronous_commit/full_page_writes for the throwaway CI Postgres, eliminating checkpoint I/O stalls).

The `pnpm/workspace` template CI has no Postgres service, so it's unchanged.

Link to Devin session: https://app.devin.ai/sessions/7943c7526d254aa4828be110fbb3f272
Requested by: @pyramation