### PR TITLE
feat: run `pgpm sync-versions` in the lerna version lifecycle

### DIFF
--- a/pgpm/workspace/package.json
+++ b/pgpm/workspace/package.json
@@ -19,7 +19,8 @@
     "clean": "pnpm -r run clean",
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
-    "deps": "pnpm up -r -i -L"
+    "deps": "pnpm up -r -i -L",
+    "version": "pgpm sync-versions"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary
Adds `"version": "pgpm sync-versions"` to the pgpm workspace template's root package.json scripts. Lerna runs the root `version` lifecycle after bumping package.json versions but before its release commit, so `pgpm sync-versions` (new command in constructive-io/constructive#1473) regenerates each module's `.control` `default_version`, Makefile sql filename, and `sql/<name>--<version>.sql` bundle from the bumped versions — and the synced files land inside lerna's own version commit. This prevents published packages from shipping stale extension metadata.

Only the `pgpm/workspace` template gets it (it has a lerna-based release flow and pgpm SQL modules); the pure-TypeScript `pnpm/workspace` template has no pgpm modules to sync.

Link to Devin session: https://app.devin.ai/sessions/94734f31443e41cba17460746a31711d
Requested by: @pyramation