### PR TITLE
chore: stage sync-versions output in the workspace boilerplate version lifecycle

### DIFF
--- a/pgpm/workspace/package.json
+++ b/pgpm/workspace/package.json
@@ -20,7 +20,7 @@
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
     "deps": "pnpm up -r -i -L",
-    "version": "pgpm sync-versions"
+    "version": "pgpm sync-versions && git add -A"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

This is the root of the release-drift we just patched in constructive-platform (#10) and pgpm-modules (#111): the `pgpm/workspace` boilerplate ships `"version": "pgpm sync-versions"`, so **every** workspace scaffolded from it inherits the same bug.

lerna runs the `version` lifecycle (`pgpm sync-versions`, which regenerates each module's `.control` / `Makefile` / `sql/<mod>--<ver>.{sql,bundle.tar.gz}`) **before** committing, then `git add`s only the files it manages (package.json / lerna.json / changelogs). The regenerated artifacts get published but left uncommitted/untagged. Having the lifecycle stage its own output pulls them into the release commit:

```diff
- "version": "pgpm sync-versions"
+ "version": "pgpm sync-versions && git add -A"
```

lerna requires a clean tree before versioning, so `git add -A` only captures what `sync-versions` produced. Only `pgpm/workspace/package.json` has this script; `pnpm/*` and `*/module` templates are unaffected.

Link to Devin session: https://app.devin.ai/sessions/a36069d7d4bc40328567bb0caa9ba250
Requested by: @pyramation