### PR TITLE
feat: quarantine third-party releases in scaffolded workspaces

### DIFF
--- a/pgpm/workspace/.github/workflows/ci.yml
+++ b/pgpm/workspace/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Install
         run: pnpm install
 
+      # Fails when pnpm-workspace.yaml no longer matches pnpm-policy.yaml, or when a
+      # third-party waiver has passed its expiry date.
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       - name: Cache pgpm CLI
         id: cache-pgpm
         uses: actions/cache@v4

--- a/pgpm/workspace/README.md
+++ b/pgpm/workspace/README.md
@@ -35,6 +35,23 @@ cd packages/your-module
 pnpm test:watch
 ```
 
+### Supply-chain policy
+
+A third-party release must be 14 days old before this workspace will install it, which is where most compromised releases are caught. Packages in `@____username____` are exempt, and `pnpm-policy.yaml` is where you widen that, approve an install script, or waive the wait for an urgent security release:
+
+```sh
+pnpm run policy        # regenerate the managed block in pnpm-workspace.yaml
+pnpm run policy:check  # CI: fail on drift or an expired waiver
+```
+
+See [pnpm-policy](https://www.npmjs.com/package/pnpm-policy) for the full configuration.
+
+Nothing is locked yet on the very first install, so it resolves every version from the registry and trips if any of them is newer than the wait. Get past it once, then commit the lockfile it produces — from then on installs replay the lockfile and the wait only applies to versions you are adding:
+
+```sh
+pnpm install --config.minimumReleaseAge=0
+```
+
 ### Prerequisites
 
 - Node.js 20+

--- a/pgpm/workspace/package.json
+++ b/pgpm/workspace/package.json
@@ -20,6 +20,8 @@
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
     "deps": "pnpm up -r -i -L",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check",
     "version": "pgpm sync-versions && git add -A"
   },
   "devDependencies": {
@@ -36,6 +38,7 @@
     "makage": "^0.5.1",
     "pgpm": "^5.19.1",
     "pgsql-test": "^5.9.7",
+    "pnpm-policy": "^0.2.2",
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/pgpm/workspace/pnpm-policy.yaml
+++ b/pgpm/workspace/pnpm-policy.yaml
@@ -1,0 +1,54 @@
+# Supply-chain policy for this workspace, enforced by pnpm itself.
+#
+# The pnpm settings it produces live in pnpm-workspace.yaml under the
+# `Managed by pnpm-policy` marker. Edit this file, then run:
+#
+#   pnpm run policy
+#
+# `pnpm run policy:check` fails CI when the two drift apart.
+#
+# https://www.npmjs.com/package/pnpm-policy
+
+# A third-party release must be this old before it can be installed. Most
+# malicious releases (compromised maintainer account, typosquat, postinstall
+# stealer) are found and yanked well inside two weeks, so the wait costs little
+# and catches the attacks that move fastest.
+minimumReleaseAge: 14d
+
+# Off by default: turning it on refuses any transitive dependency resolved from
+# git or a URL rather than the registry.
+blockExoticSubdeps: false
+
+# Scopes you own outright, emitted as `@scope/*` and exempt from the wait. npm
+# reserves `@<your-username>` for you, so your own scope is safe to claim; add
+# others only if nobody else can publish into them.
+scopes:
+  - "@____username____"
+
+# If you publish under npm accounts whose packages are not all in a scope above,
+# list the accounts here and run `pnpm pnpm-policy inventory` to query npm for
+# what they publish — waiting two weeks on your own release protects nothing:
+#
+#   maintainers:
+#     - ____username____
+#   inventory: ./pnpm-policy.inventory.json
+
+# Dependencies permitted to run install scripts. An install script is arbitrary
+# code at install time, so each entry is a deliberate decision and the value is
+# the reason it is needed:
+#
+#   allowBuilds:
+#     esbuild: native binary, downloaded at install time
+#     sharp: libvips bindings
+allowBuilds: []
+
+# Escape hatch for a third-party package that cannot wait — an urgent security
+# release, typically. A reason is required, and `until` expires the waiver so
+# `check` forces a re-justification instead of letting it become permanent:
+#
+#   exceptions:
+#     - package: lodash
+#       versions: ["4.17.21"]
+#       reason: CVE-2021-23337 fix, published today
+#       until: 2026-09-01
+exceptions: []

--- a/pgpm/workspace/pnpm-workspace.yaml
+++ b/pgpm/workspace/pnpm-workspace.yaml
@@ -1,2 +1,16 @@
 packages:
   - 'packages/*'
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2w old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 20160
+
+# Exempt from the wait: 1 scope glob(s).
+# First-party membership comes from the scopes claimed in pnpm-policy.yaml.
+minimumReleaseAgeExclude:
+  - "@____username____/*"
+
+# Off: transitive dependencies may resolve from git or a URL.
+blockExoticSubdeps: false

--- a/pnpm/workspace/.github/workflows/ci.yml
+++ b/pnpm/workspace/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Install
         run: pnpm install
 
+      # Fails when pnpm-workspace.yaml no longer matches pnpm-policy.yaml, or when a
+      # third-party waiver has passed its expiry date.
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       - name: Build
         run: pnpm -r build
 

--- a/pnpm/workspace/README.md
+++ b/pnpm/workspace/README.md
@@ -31,6 +31,23 @@ pnpm build
 pnpm lint
 ```
 
+### Supply-chain policy
+
+A third-party release must be 14 days old before this workspace will install it, which is where most compromised releases are caught. Packages in `@____username____` are exempt, and `pnpm-policy.yaml` is where you widen that, approve an install script, or waive the wait for an urgent security release:
+
+```sh
+pnpm run policy        # regenerate the managed block in pnpm-workspace.yaml
+pnpm run policy:check  # CI: fail on drift or an expired waiver
+```
+
+See [pnpm-policy](https://www.npmjs.com/package/pnpm-policy) for the full configuration.
+
+Nothing is locked yet on the very first install, so it resolves every version from the registry and trips if any of them is newer than the wait. Get past it once, then commit the lockfile it produces — from then on installs replay the lockfile and the wait only applies to versions you are adding:
+
+```sh
+pnpm install --config.minimumReleaseAge=0
+```
+
 ### Prerequisites
 
 - Node.js 20+

--- a/pnpm/workspace/package.json
+++ b/pnpm/workspace/package.json
@@ -20,7 +20,9 @@
     "clean": "pnpm -r run clean",
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
-    "deps": "pnpm up -r -i -L"
+    "deps": "pnpm up -r -i -L",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
@@ -34,6 +36,7 @@
     "jest": "^30.2.0",
     "lerna": "^9.0.3",
     "makage": "^0.5.1",
+    "pnpm-policy": "^0.2.2",
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/pnpm/workspace/pnpm-policy.yaml
+++ b/pnpm/workspace/pnpm-policy.yaml
@@ -1,0 +1,54 @@
+# Supply-chain policy for this workspace, enforced by pnpm itself.
+#
+# The pnpm settings it produces live in pnpm-workspace.yaml under the
+# `Managed by pnpm-policy` marker. Edit this file, then run:
+#
+#   pnpm run policy
+#
+# `pnpm run policy:check` fails CI when the two drift apart.
+#
+# https://www.npmjs.com/package/pnpm-policy
+
+# A third-party release must be this old before it can be installed. Most
+# malicious releases (compromised maintainer account, typosquat, postinstall
+# stealer) are found and yanked well inside two weeks, so the wait costs little
+# and catches the attacks that move fastest.
+minimumReleaseAge: 14d
+
+# Off by default: turning it on refuses any transitive dependency resolved from
+# git or a URL rather than the registry.
+blockExoticSubdeps: false
+
+# Scopes you own outright, emitted as `@scope/*` and exempt from the wait. npm
+# reserves `@<your-username>` for you, so your own scope is safe to claim; add
+# others only if nobody else can publish into them.
+scopes:
+  - "@____username____"
+
+# If you publish under npm accounts whose packages are not all in a scope above,
+# list the accounts here and run `pnpm pnpm-policy inventory` to query npm for
+# what they publish — waiting two weeks on your own release protects nothing:
+#
+#   maintainers:
+#     - ____username____
+#   inventory: ./pnpm-policy.inventory.json
+
+# Dependencies permitted to run install scripts. An install script is arbitrary
+# code at install time, so each entry is a deliberate decision and the value is
+# the reason it is needed:
+#
+#   allowBuilds:
+#     esbuild: native binary, downloaded at install time
+#     sharp: libvips bindings
+allowBuilds: []
+
+# Escape hatch for a third-party package that cannot wait — an urgent security
+# release, typically. A reason is required, and `until` expires the waiver so
+# `check` forces a re-justification instead of letting it become permanent:
+#
+#   exceptions:
+#     - package: lodash
+#       versions: ["4.17.21"]
+#       reason: CVE-2021-23337 fix, published today
+#       until: 2026-09-01
+exceptions: []

--- a/pnpm/workspace/pnpm-workspace.yaml
+++ b/pnpm/workspace/pnpm-workspace.yaml
@@ -1,2 +1,16 @@
 packages:
   - 'packages/*'
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2w old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 20160
+
+# Exempt from the wait: 1 scope glob(s).
+# First-party membership comes from the scopes claimed in pnpm-policy.yaml.
+minimumReleaseAgeExclude:
+  - "@____username____/*"
+
+# Off: transitive dependencies may resolve from git or a URL.
+blockExoticSubdeps: false


### PR DESCRIPTION
## Summary

Every workspace `pgpm init` creates now starts with a 14-day quarantine on third-party releases, which is where most compromised releases (hijacked maintainer account, typosquat, postinstall stealer) are caught and yanked. Both workspace templates (`pnpm/workspace`, `pgpm/workspace`) gain a `pnpm-policy.yaml`, the generated block in `pnpm-workspace.yaml`, `policy` / `policy:check` scripts, and a `policy:check` step in the template CI so the two cannot silently drift.

The exemption default is `@____username____/*` — npm reserves `@<your-username>` for you, so it is the one scope a scaffolded project can claim without asking. Commented next to it is how a maintainer widens that to whole npm accounts (`maintainers:` + `pnpm-policy inventory`), plus commented examples for `allowBuilds` and a time-boxed `exceptions` waiver.

Two things the templates deliberately do *not* do:

- **No blanket build approvals.** `allowBuilds: []` keeps install scripts off until someone names one and says why.
- **No standing waiver for `pnpm-policy` itself.** A scaffold has no lockfile, so its first install resolves everything from the registry and fails if any version — including `pnpm-policy` or its pinned `yamlize`/`nested-obj` — is younger than the wait. Waiving that permanently would scar the config for a transient condition, so the README documents the one-time escape instead, after which the committed lockfile makes it moot:

  ```sh
  pnpm install --config.minimumReleaseAge=0
  ```

Requires `pnpm-policy` ≥ 0.2.2 (constructive-io/dev-utils#111), which is what lets `generate`/`check` run before a lockfile exists; the templates pin `^0.2.2`.

Verified by scaffolding `pnpm/workspace` into a temp dir with the placeholders substituted: install, `policy:check` clean against the committed block, and a `--frozen-lockfile` re-install.


Link to Devin session: https://app.devin.ai/sessions/ffa3b012deac4eb7afb8f49a9af9f9ca
Requested by: @pyramation