### PR TITLE
feat: quarantine third-party releases in scaffolded workspaces

### DIFF
--- a/pgpm/workspace/.github/workflows/ci.yml
+++ b/pgpm/workspace/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Install
         run: pnpm install
 
+      # Fails when pnpm-workspace.yaml no longer matches pnpm-policy.yaml, or when a
+      # waiver has passed its expiry date.
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       - name: Cache pgpm CLI
         id: cache-pgpm
         uses: actions/cache@v4

--- a/pgpm/workspace/README.md
+++ b/pgpm/workspace/README.md
@@ -35,6 +35,21 @@ cd packages/your-module
 pnpm test:watch
 ```
 
+### Supply-chain policy
+
+A release has to be 14 days old before this workspace will install it, and no dependency may run an install script. That is where most registry attacks are caught: a hijacked account or a typosquat is usually yanked within days, and by then your install has never seen it. `pnpm-policy.yaml` is where you approve an install script or waive the wait for a security fix you need today:
+
+```sh
+pnpm run policy        # rewrite the managed block in pnpm-workspace.yaml
+pnpm run policy:check  # CI: fail on drift or an expired waiver
+```
+
+Nothing is locked yet on the very first install, so it resolves every version from the registry and trips if any of them is newer than the wait. Get past it once, then commit the lockfile — from then on installs replay the lockfile and the wait only applies to versions you are adding:
+
+```sh
+pnpm install --config.minimumReleaseAge=0
+```
+
 ### Prerequisites
 
 - Node.js 20+

--- a/pgpm/workspace/package.json
+++ b/pgpm/workspace/package.json
@@ -20,6 +20,8 @@
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
     "deps": "pnpm up -r -i -L",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check",
     "version": "pgpm sync-versions && git add -A"
   },
   "devDependencies": {
@@ -36,6 +38,7 @@
     "makage": "^0.5.1",
     "pgpm": "^5.19.1",
     "pgsql-test": "^5.9.7",
+    "pnpm-policy": "^0.2.2",
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/pgpm/workspace/pnpm-policy.yaml
+++ b/pgpm/workspace/pnpm-policy.yaml
@@ -1,0 +1,38 @@
+# Supply-chain policy for this workspace, enforced by pnpm itself.
+#
+# It produces the settings in pnpm-workspace.yaml under the `Managed by
+# pnpm-policy` marker. Edit this file, then run:
+#
+#   pnpm run policy        # rewrite the managed block
+#   pnpm run policy:check  # CI: fail if the two drift apart
+
+# How old a release must be before this workspace will install it. Attacks on the
+# registry — a hijacked maintainer account, a typosquat, a postinstall that reads
+# your environment — are usually caught and yanked within days of publication, so
+# a short wait removes most of the exposure and costs you nothing but currency.
+minimumReleaseAge: 14d
+
+# Packages allowed to run install scripts, which are arbitrary code executed on
+# your machine (and your CI) at install time. pnpm blocks them unless listed, so
+# add one only when a package genuinely needs it, and say why:
+#
+#   allowBuilds:
+#     esbuild: native binary, downloaded at install time
+#     sharp: libvips bindings
+allowBuilds: []
+
+# Skip the wait for a specific package — the case that matters is a security fix
+# published today that you need today. A reason is required, and `until` expires
+# the waiver so `policy:check` makes you re-justify it instead of letting it live
+# forever:
+#
+#   exceptions:
+#     - package: lodash
+#       versions: ["4.17.21"]
+#       reason: CVE-2021-23337 fix, published today
+#       until: 2026-09-01
+exceptions: []
+
+# Publishing to npm yourself? Then waiting on your own releases protects nothing,
+# and pnpm-policy can exempt them by scope or by npm account:
+# https://www.npmjs.com/package/pnpm-policy

--- a/pgpm/workspace/pnpm-workspace.yaml
+++ b/pgpm/workspace/pnpm-workspace.yaml
@@ -1,2 +1,11 @@
 packages:
   - 'packages/*'
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2w old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 20160
+
+# Off: transitive dependencies may resolve from git or a URL.
+blockExoticSubdeps: false

--- a/pnpm/workspace/.github/workflows/ci.yml
+++ b/pnpm/workspace/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Install
         run: pnpm install
 
+      # Fails when pnpm-workspace.yaml no longer matches pnpm-policy.yaml, or when a
+      # waiver has passed its expiry date.
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       - name: Build
         run: pnpm -r build
 

--- a/pnpm/workspace/README.md
+++ b/pnpm/workspace/README.md
@@ -31,6 +31,21 @@ pnpm build
 pnpm lint
 ```
 
+### Supply-chain policy
+
+A release has to be 14 days old before this workspace will install it, and no dependency may run an install script. That is where most registry attacks are caught: a hijacked account or a typosquat is usually yanked within days, and by then your install has never seen it. `pnpm-policy.yaml` is where you approve an install script or waive the wait for a security fix you need today:
+
+```sh
+pnpm run policy        # rewrite the managed block in pnpm-workspace.yaml
+pnpm run policy:check  # CI: fail on drift or an expired waiver
+```
+
+Nothing is locked yet on the very first install, so it resolves every version from the registry and trips if any of them is newer than the wait. Get past it once, then commit the lockfile — from then on installs replay the lockfile and the wait only applies to versions you are adding:
+
+```sh
+pnpm install --config.minimumReleaseAge=0
+```
+
 ### Prerequisites
 
 - Node.js 20+

--- a/pnpm/workspace/package.json
+++ b/pnpm/workspace/package.json
@@ -20,7 +20,9 @@
     "clean": "pnpm -r run clean",
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
-    "deps": "pnpm up -r -i -L"
+    "deps": "pnpm up -r -i -L",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
@@ -34,6 +36,7 @@
     "jest": "^30.2.0",
     "lerna": "^9.0.3",
     "makage": "^0.5.1",
+    "pnpm-policy": "^0.2.2",
     "prettier": "^3.7.4",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",

--- a/pnpm/workspace/pnpm-policy.yaml
+++ b/pnpm/workspace/pnpm-policy.yaml
@@ -1,0 +1,38 @@
+# Supply-chain policy for this workspace, enforced by pnpm itself.
+#
+# It produces the settings in pnpm-workspace.yaml under the `Managed by
+# pnpm-policy` marker. Edit this file, then run:
+#
+#   pnpm run policy        # rewrite the managed block
+#   pnpm run policy:check  # CI: fail if the two drift apart
+
+# How old a release must be before this workspace will install it. Attacks on the
+# registry — a hijacked maintainer account, a typosquat, a postinstall that reads
+# your environment — are usually caught and yanked within days of publication, so
+# a short wait removes most of the exposure and costs you nothing but currency.
+minimumReleaseAge: 14d
+
+# Packages allowed to run install scripts, which are arbitrary code executed on
+# your machine (and your CI) at install time. pnpm blocks them unless listed, so
+# add one only when a package genuinely needs it, and say why:
+#
+#   allowBuilds:
+#     esbuild: native binary, downloaded at install time
+#     sharp: libvips bindings
+allowBuilds: []
+
+# Skip the wait for a specific package — the case that matters is a security fix
+# published today that you need today. A reason is required, and `until` expires
+# the waiver so `policy:check` makes you re-justify it instead of letting it live
+# forever:
+#
+#   exceptions:
+#     - package: lodash
+#       versions: ["4.17.21"]
+#       reason: CVE-2021-23337 fix, published today
+#       until: 2026-09-01
+exceptions: []
+
+# Publishing to npm yourself? Then waiting on your own releases protects nothing,
+# and pnpm-policy can exempt them by scope or by npm account:
+# https://www.npmjs.com/package/pnpm-policy

--- a/pnpm/workspace/pnpm-workspace.yaml
+++ b/pnpm/workspace/pnpm-workspace.yaml
@@ -1,2 +1,11 @@
 packages:
   - 'packages/*'
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2w old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 20160
+
+# Off: transitive dependencies may resolve from git or a URL.
+blockExoticSubdeps: false


### PR DESCRIPTION
## Summary

A scaffolded workspace now refuses to install a release younger than 14 days, and refuses to let any dependency run an install script. That is where registry attacks land: a hijacked account or a typosquat is usually yanked within days, so a short wait means your install never sees it, and a blocked postinstall is arbitrary code that never ran on your machine or your CI.

Written for someone who only consumes packages. The config is three settings and nothing else:

```yaml
minimumReleaseAge: 14d
allowBuilds: []    # commented example: esbuild, sharp
exceptions: []     # commented example: a CVE fix published today, with an expiry
```

No `maintainers`, no `scopes`, no inventory — most people do not publish to npm, and a scaffold that ships an exemption list teaches a concept its owner does not need yet. A one-line pointer at the end says where to look if you do start publishing. This also means the templates quarantine `pgpm`, `pgsql-test` and every `@pgpm/*` release exactly like any other dependency.

Both workspace templates get the config, the generated block in `pnpm-workspace.yaml`, `policy` / `policy:check` scripts, and a `policy:check` CI step so config and generated block cannot silently drift.

One rough edge, documented rather than papered over: a scaffold has no lockfile, so the first install resolves everything from the registry and fails if any version — including `pnpm-policy` itself — is younger than the wait. A standing waiver would outlive the problem, so the README gives the one-time escape, after which the committed lockfile makes it moot:

```sh
pnpm install --config.minimumReleaseAge=0
```

Requires `pnpm-policy` ≥ 0.2.2 (constructive-io/dev-utils#111, published), which is what lets `generate`/`check` run before a lockfile exists.

Supersedes #38 and #39, which both defaulted to exempting the scaffolder's own npm scope.

Verified by scaffolding `pnpm/workspace` into a temp dir with placeholders substituted: install, `policy:check` clean against the committed block, `--frozen-lockfile` re-install; `pgpm/workspace` checks clean too, and `find-placeholders` still resolves every placeholder in the new files.


Link to Devin session: https://app.devin.ai/sessions/ffa3b012deac4eb7afb8f49a9af9f9ca
Requested by: @pyramation